### PR TITLE
Compatibility with overwrites

### DIFF
--- a/src/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php
+++ b/src/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php
@@ -336,7 +336,7 @@ class Mash2_Cobby_Model_Import_Product_Media extends Mash2_Cobby_Model_Import_Pr
     protected function _getUploader()
     {
         if (is_null($this->_fileUploader)) {
-            $this->_fileUploader    = Mage::getModel("importexport/import_uploader", null);
+            $this->_fileUploader    = Mage::getModel('importexport/import_uploader', null);
 
             $this->_fileUploader->init();
 

--- a/src/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php
+++ b/src/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php
@@ -336,7 +336,7 @@ class Mash2_Cobby_Model_Import_Product_Media extends Mash2_Cobby_Model_Import_Pr
     protected function _getUploader()
     {
         if (is_null($this->_fileUploader)) {
-            $this->_fileUploader    = new Mage_ImportExport_Model_Import_Uploader();
+            $this->_fileUploader    = Mage::getModel("importexport/import_uploader", null);
 
             $this->_fileUploader->init();
 


### PR DESCRIPTION
If you are not using Mage::getModel() to create an instance of the class, it results in a internal server error if you are uploading files if the installation uses PHP7 and the Inchoo-Patch https://github.com/Inchoo/Inchoo_PHP7/releases/tag/1.1.0

e.g.:
PHP Fatal error:  Uncaught Error: Function name must be a string in /var/www/test2.myproject.com/htdocs/app/code/core/Mage/ImportExport/Model/Import/Uploader.php:140\nStack trace:
#0 /var/www/test2.myproject.com/htdocs/app/code/core/Mage/ImportExport/Model/Import/Uploader.php(99): Mage_ImportExport_Model_Import_Uploader->_validateFile()
#1 /var/www/test2.myproject.com/htdocs/app/code/core/Mage/ImportExport/Model/Import/Uploader.php(81): Mage_ImportExport_Model_Import_Uploader->_setUploadFile('/var/www/test2....')
#2 /var/www/test2.myproject.com/htdocs/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php(289): Mage_ImportExport_Model_Import_Uploader->move('small.jpg')
#3 /var/www/test2.myproject.com/htdocs/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php(150): Mash2_Cobby_Model_Import_Product_Media->_uploadMediaFiles('small.jpg')
#4 /var/www/test2.myproject.com/htdocs/app/code/community/Mash2/Cobby/Model/Import/Product/Media.php(76): Mash2_Cobby_Model_Import_Product_Media->_processRows(Array)
#5 /var/www/test2.myproject.com/htd in /var/www/test2.myproject.com/htdocs/app/code/core/Mage/ImportExport/Model/Import/Uploader.php on line 140